### PR TITLE
国際交流ページを更新

### DIFF
--- a/css/international_fellowship.css
+++ b/css/international_fellowship.css
@@ -292,6 +292,18 @@
 	top: 100px;
 	left: 367px;
 }
+#baseContents .map .marker08 {
+	top: 230px;
+	left: 332px;
+}
+#baseContents .map .marker09 {
+	top: 290px;
+	left: 264px;
+}
+#baseContents .map .marker10 {
+	top: 80px;
+	left: 437px;
+}
 
 #baseContents .map .fukidasi {
 	border-radius: 6px;
@@ -336,10 +348,12 @@
 
 #baseContents .map .marker01:hover ~ .uniBox .university01,
 #baseContents .map .marker02:hover ~ .uniBox .university02,
-#baseContents .map .marker02:hover ~ .uniBox .university03,
-#baseContents .map .marker03:hover ~ .uniBox .university04,
-#baseContents .map .marker04:hover ~ .uniBox .university05,
-#baseContents .map .marker05:hover ~ .uniBox .university06,
-#baseContents .map .marker06:hover ~ .uniBox .university07 {
+#baseContents .map .marker03:hover ~ .uniBox .university03,
+#baseContents .map .marker04:hover ~ .uniBox .university04,
+#baseContents .map .marker05:hover ~ .uniBox .university05,
+#baseContents .map .marker06:hover ~ .uniBox .university06,
+#baseContents .map .marker08:hover ~ .uniBox .university08,
+#baseContents .map .marker09:hover ~ .uniBox .university09,
+#baseContents .map .marker10:hover ~ .uniBox .university10 {
 	color: #ff0000;
 }

--- a/international_fellowship.shtml
+++ b/international_fellowship.shtml
@@ -321,7 +321,7 @@
 							</div>
 							<img src="img/map_asia.svg" class="mapAsia">
 							<div class="uniBox">
-								<div class="university university10">大連理工大学 Dalian University of Techology 2020年5月から
+								<div class="university university10">大連理工大学 Dalian University of Technology 2020年5月から
 								</div>
 								<div class="university university09">マヒドン大学 Mahidol University 2020年3月から
 								</div>

--- a/international_fellowship.shtml
+++ b/international_fellowship.shtml
@@ -332,7 +332,7 @@
 								<div class="university university06">太原理工大学 Taiyuan University of Technology 2018年3月から
 								</div>
 								<div class="university university05">吉林大学珠海学院 Zhuhai College of Jilin University
-									2015年10月から</div>
+									2015年3月から</div>
 								<div class="university university04">チェラロンコン大学 Chulalongkorn University 2015年3月から</div>
 								<div class="university university03">香港理工大学 The Hong Kong Polytechnic University
 									2014年3月から</div>

--- a/international_fellowship.shtml
+++ b/international_fellowship.shtml
@@ -327,7 +327,7 @@
 								</div>
 								<div class="university university08">北部湾大学 Beibu Gulf University 2020年3月から
 								</div>
-								<div class="university university07">ラ・ドローブ大学 La Trobe University 2019年12月から
+								<div class="university university07">ラ・トローブ大学 La Trobe University 2019年12月から
 								</div>
 								<div class="university university06">太原理工大学 Taiyuan University of Technology 2018年3月から
 								</div>

--- a/international_fellowship.shtml
+++ b/international_fellowship.shtml
@@ -311,6 +311,9 @@
 							<img src="img/marker.svg" class="marker marker04">
 							<img src="img/marker.svg" class="marker marker05">
 							<img src="img/marker.svg" class="marker marker06">
+							<img src="img/marker.svg" class="marker marker08">
+							<img src="img/marker.svg" class="marker marker09">
+							<img src="img/marker.svg" class="marker marker10">
 							<div class="fukidasi">
 								<div class="fukidasiInner">
 									<img src="img/KUT_logo.gif">
@@ -318,15 +321,21 @@
 							</div>
 							<img src="img/map_asia.svg" class="mapAsia">
 							<div class="uniBox">
-								<div class="university university07">太原理工大学 Taiyuan University of Technology 2018年3月から
+								<div class="university university10">大連理工大学 Dalian University of Techology 2020年5月から
 								</div>
-								<div class="university university06">吉林大学珠海学院 Zhuhai College of Jilin University
+								<div class="university university09">マヒドン大学 Mahidol University 2020年3月から
+								</div>
+								<div class="university university08">北部湾大学 Beibu Gulf University 2020年3月から
+								</div>
+								<div class="university university07">ラ・ドローブ大学 La Trobe University 2019年12月から
+								</div>
+								<div class="university university06">太原理工大学 Taiyuan University of Technology 2018年3月から
+								</div>
+								<div class="university university05">吉林大学珠海学院 Zhuhai College of Jilin University
 									2015年10月から</div>
-								<div class="university university05">チェラロンコン大学 Chulalongkorn University 2015年3月から</div>
-								<div class="university university04">香港理工大学 The Hong Kong Polytechnic University
+								<div class="university university04">チェラロンコン大学 Chulalongkorn University 2015年3月から</div>
+								<div class="university university03">香港理工大学 The Hong Kong Polytechnic University
 									2014年3月から</div>
-								<div class="university university03">北京科技大学 University of Science and Technology Beijing
-									2013年9月から</div>
 								<div class="university university02">北京理工大学 Beijing Institute of Technology 2009年3月から
 								</div>
 								<div class="university university01">吉林大学 Jilin University 2008年10月から</div>
@@ -355,12 +364,14 @@
 					<div class="detailInner">
 						<div class="subTitle">
 							<div class="circle"></div>
-							<div class="titleName">外国人留学生(2018年6月現在)</div>
+							<div class="titleName">外国人留学生(2020年10月現在)</div>
 						</div>
 						<ul>
-							<li>中国 10名</li>
-							<li>タイ 1名</li>
-							<li>イラン 1名</li>
+							<li>中国 11名</li>
+							<li>タイ 2名</li>
+							<li>スイス 1名</li>
+							<li>南スーダン 1名</li>
+							<li>ロシア 1名</li>
 						</ul>
 						の他、各国から多くの研究室生を受け入れています。
 					</div>


### PR DESCRIPTION
international_fellowship.css
追加された協定校がmap上でわかるようにピンを追加
international_fellowship.shtml
協定校一覧
北京科技大学を削除
大原理工大学、ラ・トローブ大学、
北部湾大学、マヒドン大学を追加
外国人留学生
2020年10月現在の情報に更新